### PR TITLE
BlogのText_areaに改行機能の追加&Htmlタグのエスケープ処理の追加

### DIFF
--- a/app/views/blogs/_form.html.erb
+++ b/app/views/blogs/_form.html.erb
@@ -27,7 +27,11 @@
 
 <p>
   <%= f.label :text %>
-  <%= f.text_area :text %>
+  <% if blog.text? %> <!--BlogのTEXTが存在する場合 -->
+   <%= simple_format(h(blog.text)) %> <!--Blog textの改行処理 & タグのエスケープ処理 -->
+  <% else %>
+   <%= f.text_area :text %> <!--BlogのTEXTが存在しない場合TEXT AREAを表示する -->
+  <% end %>
 </p>
 
   <%= f.hidden_field :user_id, value: current_user.id %>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -17,7 +17,7 @@
 
 <p>
   <strong>Text</strong>
-  <%= @blog.text %>
+  <%= simple_format(h(@blog.text)) %> <!--Blog textの改行 -->
 </p>
 
 


### PR DESCRIPTION
simple_formatで改行機能の追加(If文で条件分岐。Blogのtextが存在するならsimple_form、それ以外はText_areaを表示する)&タグのエスケープ処理を追加(Text_areaに<b></b>などのタグを入れると太字に変換されるため)